### PR TITLE
Fix dish update logic

### DIFF
--- a/lib/Coocook/Controller/Dish.pm
+++ b/lib/Coocook/Controller/Dish.pm
@@ -186,8 +186,8 @@ sub update : POST Chained('base') Args(0) RequiresCapability('edit_project') {
                 if ( $c->req->params->get( 'delete' . $ingredient->id ) ) {
                     $ingredient->delete;
 
-                    if ( not( $item and $item->ingredients->exists ) ) {
-                        $item->delete();
+                    if ( $item ? not $item->ingredients->exists : 1 ) {
+                        $item->delete() if $item;
                         next;
                     }
                 }


### PR DESCRIPTION
In `Controller::Dish` a purchase list item of an ingredient now gets deleted when an ingredient gets deleted and no other ingredients are assigned to it. Before deleting the item it is checked if the item exists.